### PR TITLE
fix(release): sync config.yml version and unblock auto-release pipeline

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,7 +29,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN must be a PAT with 'contents: write' whose owner is
+          # listed under Settings → Branches → Allow specified actors to bypass
+          # required pull requests.  Without it the push is blocked by the
+          # "Changes must be made through a pull request" branch-protection rule.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
@@ -47,13 +51,14 @@ jobs:
           echo "  new    : $NEW"
           sed -i.bak -E "s/^__version__ = \".*\"/__version__ = \"$NEW\"/" asr_deepspeech/__init__.py
           rm asr_deepspeech/__init__.py.bak
+          sed -i "s/^  version:[[:space:]]*v[0-9.]*$/  version:                  v${NEW}/" asr_deepspeech/config.yml
           echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Commit + tag
         run: |
           set -euo pipefail
-          git add asr_deepspeech/__init__.py
+          git add asr_deepspeech/__init__.py asr_deepspeech/config.yml
           git commit -m "chore(release): v${{ steps.bump.outputs.new_version }} [skip release]"
           git tag "${{ steps.bump.outputs.tag }}"
           git push origin HEAD:${{ github.ref_name }}

--- a/asr_deepspeech/config.yml
+++ b/asr_deepspeech/config.yml
@@ -87,7 +87,7 @@ inference:
   num_workers:              32
 
 meta:
-  version:                  v0.3.0
+  version:                  v0.4.2
   root:                     "{{ *gold }}"
   root_data:                "{{ *gold }}/{{ *id_model }}"
   output_file:              "{{ *gold }}/{{ *id_model }}/output.txt"


### PR DESCRIPTION
## Summary

- Updates `asr_deepspeech/config.yml` `meta.version` from `v0.3.0` to `v0.4.2` to match `__init__.py` and the latest GitHub release tag
- Fixes auto-release workflow to also bump `config.yml` `meta.version` alongside `__init__.py` on each release, keeping them permanently in sync
- Adds `asr_deepspeech/config.yml` to the release commit so version drift can't recur
- Switches the checkout `token` to `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` so the version-bump push can bypass master branch protection when a PAT is configured

## Root cause

The auto-release workflow has been failing since branch protection was added to `master` (`GH006: Protected branch update failed — Changes must be made through a pull request`). Because `bump-and-release` fails, `publish-pypi` never runs, leaving PyPI pinned at 0.3.2 while GitHub tags advanced to v0.4.2.

## Unblocking PyPI publish

To restore the pipeline after this PR lands:

1. Create a GitHub Personal Access Token (classic) with `repo` scope for a user who is listed under **Settings → Branches → master → Allow specified actors to bypass required pull requests**.
2. Add it as a repository secret named `RELEASE_TOKEN`.
3. Trigger the auto-release workflow manually via `workflow_dispatch` to publish v0.4.3 to PyPI.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)