### PR TITLE
ci: add CodeQL SAST workflow for Python security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  schedule:
+    - cron: "0 4 * * 1"  # weekly Monday 04:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` with the standard GitHub CodeQL starter workflow for Python
- Runs on push/PR to `master`/`main` and on a weekly Monday 04:00 UTC schedule
- Grants `security-events: write` only to the `analyze` job; top-level permissions default to `read`
- Pins all action SHAs (`actions/checkout@v4`, `github/codeql-action v3.36.2`) matching the repo's existing security posture
- Enables `security-and-quality` query suite to catch both vulnerability patterns and code quality issues

Closes #26.

## Test plan

- [ ] Confirm the workflow appears in the GitHub Actions tab after merge
- [ ] Confirm CodeQL results appear in the GitHub Security tab (Advanced Security → Code scanning alerts)
- [ ] Confirm the weekly schedule trigger is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)