### PR TITLE
fix: add CycloneDX SBOM to PyPI publish workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -91,6 +92,14 @@ jobs:
         run: |
           pip install build
           python -m build --outdir dist
+
+      - name: Generate SBOM
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py environment -o sbom.json
+          gh release upload "${{ needs.bump-and-release.outputs.tag }}" sbom.json --clobber
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1


### PR DESCRIPTION
Closes #25

## Summary

- Adds `contents: write` permission to the `publish-pypi` job so it can upload release assets
- Installs `cyclonedx-bom` after building the wheel/sdist
- Runs `cyclonedx-py environment -o sbom.json` to generate a CycloneDX SBOM covering the published environment
- Uploads `sbom.json` to the GitHub release via `gh release upload` so consumers can verify the supply chain of each PyPI release

## Why

The public PyPI package had no SBOM, making it impossible for downstream users to audit the dependency tree or perform supply-chain risk assessments. This satisfies standard SBOM requirements (NTIA minimum elements, CycloneDX format) with minimal workflow overhead.