### PR TITLE
fix(ci): import torch at module level + ruff fixes (restore green master)

### DIFF
--- a/asr_deepspeech/modules/deepspeech.py
+++ b/asr_deepspeech/modules/deepspeech.py
@@ -2,6 +2,7 @@ import math
 from collections import OrderedDict
 
 import pandas as pd
+import torch
 from ascii_graph import Pyasciigraph
 from torch import nn
 
@@ -283,8 +284,6 @@ class DeepSpeech(nn.Module):
 
 
 if __name__ == "__main__":
-    import torch
-
     from asr_deepspeech import cfg
 
     # # Instantiate the model, optimizer and scheduler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
 import pytest
 import soundfile as sf
-from types import SimpleNamespace
 
 # Set config path before importing asr_deepspeech to avoid path resolution issues on Windows
 config_path = Path(__file__).parent.parent / "asr_deepspeech" / "config.yml"

--- a/tests/test_greedy_decoder.py
+++ b/tests/test_greedy_decoder.py
@@ -1,5 +1,6 @@
-import torch
 import pytest
+import torch
+
 from asr_deepspeech.decoders import GreedyDecoder
 
 # Labels: blank=0, then A-E, then space

--- a/tests/test_spectrogram_dataset.py
+++ b/tests/test_spectrogram_dataset.py
@@ -1,23 +1,24 @@
+import pandas as pd
+import pytest
 import torch
 import torch.nn as nn
-import pytest
-import pandas as pd
-from asr_deepspeech.data.parsers import SpectrogramParser
+
+from asr_deepspeech.audio.wav_converter import WAVConverter
 from asr_deepspeech.data.dataset import SpectrogramDataset
-from asr_deepspeech.functional import _collate_fn, check_loss, to_np
 from asr_deepspeech.data.loaders import AudioDataLoader
-from asr_deepspeech.modules.blocks import (
-    SequenceWise,
-    InferenceBatchSoftmax,
-    Lookahead,
-    BatchRNN,
-    MaskConv,
-)
-from asr_deepspeech.modules.deepspeech import DeepSpeech
+from asr_deepspeech.data.parsers import SpectrogramParser
 from asr_deepspeech.etl.jsut_dataset import JSUTDataset
 from asr_deepspeech.etl.librispeech_dataset import LibriSpeechDataset
+from asr_deepspeech.functional import _collate_fn, check_loss, to_np
 from asr_deepspeech.loggers.tensorboard_logger import TensorBoardLogger
-from asr_deepspeech.audio.wav_converter import WAVConverter
+from asr_deepspeech.modules.blocks import (
+    BatchRNN,
+    InferenceBatchSoftmax,
+    Lookahead,
+    MaskConv,
+    SequenceWise,
+)
+from asr_deepspeech.modules.deepspeech import DeepSpeech
 
 # Labels map: char -> int index.  Index 0 is intentionally unused (CTC blank).
 LABELS_MAP = {c: i + 1 for i, c in enumerate("abcdefghijklmnopqrstuvwxyz ")}
@@ -220,6 +221,7 @@ def test_check_loss_nan():
 
 def test_to_np_converts_tensor():
     import numpy as np
+
     t = torch.tensor([1.0, 2.0, 3.0])
     arr = to_np(t)
     assert isinstance(arr, np.ndarray)
@@ -458,6 +460,7 @@ def test_tensorboard_logger_init(tmp_path):
 
 def test_tensorboard_logger_load_previous_values(tmp_path):
     import torch
+
     logger = TensorBoardLogger(
         id="test_run",
         log_dir=str(tmp_path / "tb_logs2"),
@@ -474,6 +477,7 @@ def test_tensorboard_logger_load_previous_values(tmp_path):
 
 def test_tensorboard_logger_update(tmp_path):
     import torch
+
     logger = TensorBoardLogger(
         id="test_run",
         log_dir=str(tmp_path / "tb_logs3"),
@@ -538,7 +542,7 @@ def test_deepspeech_call_with_loader(audio_conf, label_csv):
     # Build a minimal fake loader: one batch with shape matching model expectations
     # Input: (B=1, 1, freq, time=40), targets: flat int tensor, percentages, sizes
     inputs = torch.randn(1, 1, EXPECTED_FREQ_BINS, 40)
-    targets = torch.IntTensor([1, 2, 3])   # 3 chars
+    targets = torch.IntTensor([1, 2, 3])  # 3 chars
     input_percentages = torch.FloatTensor([1.0])
     target_sizes = torch.IntTensor([3])
 


### PR DESCRIPTION
## Summary

Master CI (the **Test** workflow) is red. Two distinct failures, one root cause plus a lint cleanup:

1. **`test` job — failing test + coverage gate.** `tests/test_spectrogram_dataset.py::test_deepspeech_call_with_loader` crashed with `NameError: name 'torch' is not defined` at `asr_deepspeech/modules/deepspeech.py:171` (`with torch.no_grad():`). `torch` was only imported inside the module's `if __name__ == "__main__"` guard, so **any import-time use of `torch.load` / `torch.no_grad` raised `NameError`** — a real runtime bug, not just a test issue. With that path crashing, total coverage sat at 47.67%, under the `--cov-fail-under=50` gate.
2. **`lint` job — ruff.** The test files added in #54 weren't import-sorted/formatted, so `ruff check .` (I001 ×3) and `ruff format --check .` failed.

## Changes

- `asr_deepspeech/modules/deepspeech.py`: add module-level `import torch`; remove the now-redundant local import in the `__main__` guard.
- `tests/`: ruff import-sort + format autofixes (no behavioural change).

## Verification (local)

- `ruff check .` → All checks passed; `ruff format --check .` → clean.
- `pytest tests/ --cov=asr_deepspeech --cov-fail-under=50` → **62 passed**, total coverage **52.16%** (deepspeech.py 46% → 82%).

> Note: the **Auto-release** workflow's `publish-pypi` step is separately red with a PyPI *trusted-publishing* `invalid-publisher` error — that's an external pypi.org config (no trusted publisher registered for this repo/workflow/environment) and is out of scope for this code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)