### PR TITLE
chore(ci): disable PyPI publish until trusted publisher is provisioned

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -101,5 +101,10 @@ jobs:
           cyclonedx-py environment -o sbom.json
           gh release upload "${{ needs.bump-and-release.outputs.tag }}" sbom.json --clobber
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      # Temporarily disabled: PyPI Trusted Publishing rejects the OIDC token
+      # ("invalid-publisher": no matching publisher configured on pypi.org for
+      # this repo/workflow/environment). A request is open with PyPI; until they
+      # provision the trusted publisher, this step would fail every release and
+      # block the pipeline. Re-enable by uncommenting once PyPI confirms.
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1


### PR DESCRIPTION
## Summary

The Auto-release `publish-pypi` job's **Publish to PyPI** step fails on every release with PyPI Trusted Publishing `invalid-publisher` (no matching publisher configured on pypi.org for this repo/workflow/environment). A request is open with PyPI; until they provision it, this step only turns the pipeline red and blocks us.

This **comments out** the Publish to PyPI step (kept pinned + documented) so it no longer runs.

## What still happens on release

- `bump-and-release`: version bump, tag, GitHub release — unchanged.
- `publish-pypi`: still builds wheel/sdist and **uploads the SBOM** to the release; just no PyPI upload.

## Re-enabling

Uncomment the step once PyPI confirms the trusted publisher. No other change needed (`id-token: write` / `environment: release` left in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)