### PR TITLE
docs: add example_conf.env and configuration docs (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,25 @@ You should be able to get an output like
 =1= TEST PASSED : asr_deepspeech.trainers
 ```
 
+# Configuration
+
+The application is driven by a single YAML config (`asr_deepspeech/config.yml`) loaded into the
+global `cfg` object at import time. To point the package at your own config without editing the
+bundled file, set the `ZAK_ASR_CONFIG` environment variable to the path of your YAML.
+
+An example environment file is provided. Copy it to `.env`, adjust the values, and load it before
+running the package:
+
+```bash
+cp example_conf.env .env
+export $(grep -v '^#' .env | xargs)
+```
+
+`.env` is gitignored, so your local configuration is never committed.
+
 # Datasets
 
-By default we process the JSUT dataset. See the `config` section to know how to process a custom dataset.
+By default we process the JSUT dataset. See the [Configuration](#configuration) section to know how to process a custom dataset.
 ```python
 from gnutools.remote import gdrive
 from asr_deepspeech import cfg

--- a/example_conf.env
+++ b/example_conf.env
@@ -1,0 +1,16 @@
+# Example environment configuration for asr-deepspeech.
+#
+# Copy this file to `.env` and adjust the values to suit your setup:
+#
+#     cp example_conf.env .env
+#
+# Then load it before running the package, e.g.:
+#
+#     export $(grep -v '^#' .env | xargs)
+#
+# `.env` is gitignored on purpose — never commit your real configuration.
+
+# Path to the ASR config YAML used to build the global `cfg` object
+# (see asr_deepspeech/__init__.py). When unset, asr_deepspeech falls back to
+# the bundled asr_deepspeech/config.yml.
+ZAK_ASR_CONFIG=asr_deepspeech/config.yml


### PR DESCRIPTION
Recreates #60 on the cleaned `master` after the git history rewrite that removed accidentally-committed `docs/superpowers/` files.

- Original change and authorship by @tomctr are preserved (commit cherry-picked onto the clean base).
- Adds `example_conf.env` and updates `README.md` configuration docs.

Closes #18. Supersedes #60.