### PR TITLE
fix: add missing ASR example env template

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ pip install asr-deepspeech
 uv pip install asr-deepspeech
 ```
 
+If you want to run the project with an explicit configuration file, copy
+`example_conf.env` to `.env` and source it before launching the package. The
+template points `ZAK_ASR_CONFIG` at the bundled `asr_deepspeech/config.yml`.
+
 
 # Makefile commands
 Exhaustive list of make commands:

--- a/example_conf.env
+++ b/example_conf.env
@@ -1,0 +1,1 @@
+ZAK_ASR_CONFIG=asr_deepspeech/config.yml


### PR DESCRIPTION
Closes #18\n\nAdd the missing example_conf.env template referenced by the repository guidance and document how to copy it to .env.